### PR TITLE
Keep source health out of draft recommendations

### DIFF
--- a/scripts/draft/replay-sleeper-boards.ts
+++ b/scripts/draft/replay-sleeper-boards.ts
@@ -65,7 +65,6 @@ async function main() {
         draft: artifact.sleeper.draftDetails,
         picks: priorPicks,
         userId: artifact.state.config.userId,
-        sourceWarnings: bundle.sourceHealth?.warnings ?? [],
       });
       const board = viewModel.recommendationBoard;
       const recommendation = board?.topRecommendation?.player ?? null;

--- a/src/app/api/draft/view-model/route.ts
+++ b/src/app/api/draft/view-model/route.ts
@@ -43,7 +43,6 @@ export async function GET(req: NextRequest) {
       draft,
       picks,
       userId,
-      sourceWarnings: bundle.sourceHealth?.warnings ?? [],
     });
     return NextResponse.json(vm);
   } catch (e) {

--- a/src/app/draft-assistant/_components/DraftStatusCard.tsx
+++ b/src/app/draft-assistant/_components/DraftStatusCard.tsx
@@ -126,10 +126,8 @@ export default function DraftStatusCard() {
   }
 
   const [collapsed, setCollapsed] = React.useState(false);
-  const draftSources =
-    sourceHealth?.sources.filter((source) => source.source !== "Footballguys") ?? [];
-  const sourceWarnings =
-    sourceHealth?.warnings.filter((warning) => !warning.startsWith("Footballguys")) ?? [];
+  const draftSources = sourceHealth?.sources ?? [];
+  const sourceWarnings = sourceHealth?.warnings ?? [];
   const sourceWarningCount = sourceWarnings.length;
 
   return (

--- a/src/app/draft-assistant/_components/PreviewPickDialog.tsx
+++ b/src/app/draft-assistant/_components/PreviewPickDialog.tsx
@@ -190,7 +190,7 @@ function PlayerDecisionPanel({
       </div>
       <div className="flex flex-wrap gap-1">
         {(player.draft_reason_labels ?? [])
-          .filter((reason) => isUsefulCopy(reason) && reason !== "Source warning")
+          .filter(isUsefulCopy)
           .map((reason) => (
           <Badge key={reason} variant="outline">
             {reason}

--- a/src/app/draft-assistant/_contexts/DraftDataContext.tsx
+++ b/src/app/draft-assistant/_contexts/DraftDataContext.tsx
@@ -668,13 +668,11 @@ export function DraftDataProvider({
       picks: picks || [],
       userId: user.user_id,
       topLimit: 3,
-      sourceWarnings: playersBundle?.sourceHealth?.warnings ?? [],
     });
   }, [
     playersMap,
     draftDetails,
     picks,
-    playersBundle?.sourceHealth?.warnings,
     user?.user_id,
   ]);
 

--- a/src/app/mock-draft/MockDraftRoom.tsx
+++ b/src/app/mock-draft/MockDraftRoom.tsx
@@ -220,7 +220,6 @@ export default function MockDraftRoom() {
       picks: draftPicks,
       userId: draftState.config.userId,
       topLimit: 4,
-      sourceWarnings: bundle.data.sourceHealth?.warnings ?? [],
     });
   }, [bundle.data, draftDetails, draftPicks, draftState, players.length]);
 

--- a/src/lib/algoMockDraft.ts
+++ b/src/lib/algoMockDraft.ts
@@ -128,7 +128,6 @@ export function runAlgorithmMockDraft(input: {
     picks: finalDraftPicks,
     userId: state.config.userId,
     topLimit: 4,
-    sourceWarnings: input.bundle.sourceHealth?.warnings ?? [],
   });
   const artifact = createMockDraftResultArtifact({
     state,
@@ -160,7 +159,6 @@ function buildAlgorithmDecisionContext(input: {
     picks: draftPicks,
     userId: input.state.config.userId,
     topLimit: 4,
-    sourceWarnings: input.bundle.sourceHealth?.warnings ?? [],
   });
   const board = viewModel.recommendationBoard;
 

--- a/src/lib/draftState.ts
+++ b/src/lib/draftState.ts
@@ -643,7 +643,6 @@ export function buildDraftViewModel(args: {
   picks: DraftPick[];
   userId?: string;
   topLimit?: number;
-  sourceWarnings?: readonly string[];
 }) {
   const {
     playersMap,
@@ -651,7 +650,6 @@ export function buildDraftViewModel(args: {
     picks,
     userId,
     topLimit = 3,
-    sourceWarnings = [],
   } = args;
   const base = buildDraftState({ playersMap, draft, picks });
 
@@ -743,7 +741,6 @@ export function buildDraftViewModel(args: {
         draftWideNeeds,
         teamRosterStates,
         userRosterPlayers: userRoster.players,
-        sourceWarnings,
       })
     : null;
   const draftContext = buildDraftContext({

--- a/src/lib/draftValue/index.ts
+++ b/src/lib/draftValue/index.ts
@@ -28,7 +28,6 @@ export type DraftValueReasonCode =
   | "ONESIE_WAIT"
   | "BENCH_UPSIDE"
   | "K_DEF_WAIT"
-  | "SOURCE_WARNING"
   | "NEWS_RISK";
 
 export type DraftValueReason = {
@@ -203,7 +202,6 @@ export type DraftValueBoardInput<TPlayer extends DraftValuePlayerInput> = {
   draftWideNeeds?: Partial<Record<Position | "FLEX", number>> | undefined;
   teamRosterStates?: readonly DraftTeamRosterState[] | undefined;
   userRosterPlayers?: readonly DraftRosterPlayerInput[] | undefined;
-  sourceWarnings?: readonly string[] | undefined;
 };
 
 export type DraftValueBoard<TPlayer extends DraftValuePlayerInput> = {
@@ -1811,7 +1809,6 @@ function byeCoverageText(args: {
 function dataQualityText(args: {
   missingFields: readonly string[];
   injuryRisk: { penalty: number; status: string | null; notes: string | null };
-  sourceWarnings?: readonly string[] | undefined;
 }) {
   return uniqueStrings([
     args.missingFields.includes("ecr") ? "FantasyPros ECR average missing." : null,
@@ -1821,7 +1818,6 @@ function dataQualityText(args: {
     args.injuryRisk.penalty > 0
       ? `Injury/news flag: ${args.injuryRisk.status ?? "check player news"}.`
       : null,
-    args.sourceWarnings?.length ? "Source warning; check freshness." : null,
   ]);
 }
 
@@ -1839,7 +1835,6 @@ function buildRecommendationExplanation(args: {
   rosterPlayers: readonly DraftRosterPlayerInput[];
   missingFields: readonly string[];
   injuryRisk: { penalty: number; status: string | null; notes: string | null };
-  sourceWarnings?: readonly string[] | undefined;
 }) {
   const pros: string[] = [];
   const cons: string[] = [];
@@ -1943,7 +1938,6 @@ function buildRecommendationExplanation(args: {
   const dataQuality = dataQualityText({
     missingFields: args.missingFields,
     injuryRisk: args.injuryRisk,
-    sourceWarnings: args.sourceWarnings,
   });
 
   return {
@@ -2496,13 +2490,6 @@ export function buildDraftValueBoard<TPlayer extends DraftValuePlayerInput>(
         detail: `${directNeeds} open ${player.position} needs remain across the room.`,
       });
     }
-    if (input.sourceWarnings?.length) {
-      reasons.push({
-        code: "SOURCE_WARNING",
-        label: "Source warning",
-        detail: input.sourceWarnings.slice(0, 2).join(" "),
-      });
-    }
     if (injuryRisk.penalty > 0) {
       reasons.push({
         code: "NEWS_RISK",
@@ -2526,7 +2513,6 @@ export function buildDraftValueBoard<TPlayer extends DraftValuePlayerInput>(
       rosterPlayers: input.userRosterPlayers ?? [],
       missingFields,
       injuryRisk,
-      sourceWarnings: input.sourceWarnings,
     });
 
     return [

--- a/src/lib/schemas-bundle.ts
+++ b/src/lib/schemas-bundle.ts
@@ -55,6 +55,7 @@ export const AggregatesBundlePlayer = z.object({
 export type AggregatesBundlePlayerT = z.infer<typeof AggregatesBundlePlayer>;
 
 export const AggregateSourceHealthItem = z.object({
+  // Footballguys remains parseable for historical draft-result snapshots.
   source: z.enum(["Sleeper", "FantasyPros", "Tiers", "Footballguys"]),
   status: z.enum(["ok", "warning", "missing"]),
   lastUpdated: z.string().nullable(),

--- a/src/lib/sourceHealth.ts
+++ b/src/lib/sourceHealth.ts
@@ -2,12 +2,11 @@ import * as fs from "fs";
 import * as path from "path";
 import type { ScoringType } from "@/lib/schemas";
 import type { CombinedEntryT } from "@/lib/schemas-aggregates";
-import { FootballguysPublicRankingsSchema } from "@/lib/footballguysRankings";
 
 export type AggregateSourceStatus = "ok" | "warning" | "missing";
 
 export type AggregateSourceHealthItem = {
-  source: "Sleeper" | "FantasyPros" | "Tiers" | "Footballguys";
+  source: "Sleeper" | "FantasyPros" | "Tiers";
   status: AggregateSourceStatus;
   lastUpdated: string | null;
   fetchedAt: string | null;
@@ -339,54 +338,6 @@ function sleeperHealth(
   } satisfies AggregateSourceHealthItem;
 }
 
-function footballguysHealth(now: Date): AggregateSourceHealthItem {
-  const filePath = path.resolve(
-    process.cwd(),
-    "public/data/aggregate/footballguys-rankings.json"
-  );
-  if (!fs.existsSync(filePath)) {
-    return {
-      source: "Footballguys",
-      status: "missing",
-      lastUpdated: null,
-      fetchedAt: null,
-      rowCount: null,
-      relevantRowCount: null,
-      coveragePct: null,
-      coverageBasis: null,
-      sampleSize: null,
-      projectionsFetched: null,
-      warnings: ["Footballguys public-default rankings are missing."],
-    };
-  }
-  const data = FootballguysPublicRankingsSchema.parse(
-    JSON.parse(fs.readFileSync(filePath, "utf8"))
-  );
-  const consensus = data.sources.find((source) => source.source === "consensus");
-  const warnings = [
-    "Footballguys rankings use public-default 12-team PPR settings, not this league's custom settings.",
-  ];
-  addFreshnessWarning({
-    warnings,
-    source: "Footballguys",
-    updatedAt: data.fetchedAt,
-    now,
-  });
-  return {
-    source: "Footballguys",
-    status: statusFromWarnings(warnings),
-    lastUpdated: null,
-    fetchedAt: data.fetchedAt,
-    rowCount: data.rows.length,
-    relevantRowCount: consensus?.adpRowCount ?? null,
-    coveragePct: consensus?.adpCoveragePct ?? null,
-    coverageBasis: "consensus ADP among Footballguys ranked players",
-    sampleSize: null,
-    projectionsFetched: null,
-    warnings,
-  };
-}
-
 export function getAggregateSourceHealth(args: {
   scoring: ScoringType;
   players: readonly CombinedEntryT[];
@@ -403,7 +354,6 @@ export function getAggregateSourceHealth(args: {
     sleeperHealth(args.players, args.scoring, draftCapacity, now),
     fantasyProsHealth(metadata, args.scoring, now),
     tiersHealth(metadata, args.scoring, now),
-    footballguysHealth(now),
   ];
   return {
     generatedAt: now.toISOString(),

--- a/tests/api/draftViewModelRoute.test.ts
+++ b/tests/api/draftViewModelRoute.test.ts
@@ -95,7 +95,6 @@ describe("GET /api/draft/view-model", () => {
       draft,
       picks,
       userId: "user-1",
-      sourceWarnings: ["stale"],
     });
   });
 

--- a/tests/app/draft-assistant/PreviewPickDialog.test.tsx
+++ b/tests/app/draft-assistant/PreviewPickDialog.test.tsx
@@ -39,8 +39,7 @@ const selected = {
   sleeper_injury_status: "Questionable",
   sleeper_injury_notes: "Limited at practice.",
   draft_action_label: "unknown",
-  draft_reason_labels: ["Best value", "Source warning"],
-  draft_data_quality_notes: ["Source warning; check freshness."],
+  draft_reason_labels: ["Best value"],
 } satisfies PreviewPickPlayer;
 
 function decisionPlayer(id: string, name: string, score: number): PlayerWithPick {

--- a/tests/lib/draftResults.test.ts
+++ b/tests/lib/draftResults.test.ts
@@ -62,6 +62,24 @@ describe("draft result artifacts", () => {
       draftDetails,
       draftPicks,
       viewModel: { recommendation: choice },
+      sourceHealth: {
+        generatedAt: "2026-07-01T12:00:00.000Z",
+        scoring: "ppr",
+        sources: [
+          {
+            source: "Footballguys",
+            status: "warning",
+            lastUpdated: null,
+            fetchedAt: "2026-07-01T11:00:00.000Z",
+            rowCount: 500,
+            coveragePct: null,
+            sampleSize: null,
+            projectionsFetched: null,
+            warnings: ["Legacy snapshot warning."],
+          },
+        ],
+        warnings: ["Footballguys: Legacy snapshot warning."],
+      },
       exportedAt: "2026-07-01T12:00:00.000Z",
     });
 

--- a/tests/lib/draftValue.test.ts
+++ b/tests/lib/draftValue.test.ts
@@ -672,7 +672,7 @@ describe("buildDraftValueBoard", () => {
     );
   });
 
-  it("adds source and news risk reasons without hiding usable value", () => {
+  it("adds player news risk without hiding usable value", () => {
     const board = buildDraftValueBoard({
       players: [
         {
@@ -702,15 +702,12 @@ describe("buildDraftValueBoard", () => {
         { name: "RB B", position: "RB", bye_week: 8 },
         { name: "TE A", position: "TE", bye_week: 8 },
       ],
-      sourceWarnings: ["FantasyPros projections were not fetched."],
     });
 
     const reasons = board.metricsByPlayerId.wr1?.reasons.map(
       (reason) => reason.code
     );
-    expect(reasons).toEqual(
-      expect.arrayContaining(["SOURCE_WARNING", "NEWS_RISK"])
-    );
+    expect(reasons).toContain("NEWS_RISK");
     expect(board.rosterConstruction.byeWarnings).toContain(
       "3 RB/WR/TE players share Week 8 bye."
     );

--- a/tests/lib/sourceHealth.test.ts
+++ b/tests/lib/sourceHealth.test.ts
@@ -67,7 +67,6 @@ describe("getAggregateSourceHealth", () => {
       "Sleeper",
       "FantasyPros",
       "Tiers",
-      "Footballguys",
     ]);
     expect(
       health.sources.every((source) =>


### PR DESCRIPTION
## Description

Removes global provider warnings from player-level draft recommendations and limits newly generated live draft source health to Sleeper, FantasyPros, and generated tiers. Footballguys rankings and team grading remain available for offline/post-draft analysis, while historical artifacts containing Footballguys source snapshots remain parseable.

## Changes by file

- `src/lib/draftValue/index.ts`: removes global source warnings from recommendation reasons and data-quality copy.
- `src/lib/draftState.ts`: removes source-warning plumbing from the canonical draft view model.
- `src/lib/sourceHealth.ts`: stops generating Footballguys health entries for live draft bundles.
- `src/lib/schemas-bundle.ts`: documents legacy Footballguys parsing support for saved artifacts.
- `src/app/draft-assistant/_components/DraftStatusCard.tsx`: consumes the cleaned live source-health payload directly.
- `src/app/draft-assistant/_components/PreviewPickDialog.tsx`: removes obsolete special-case filtering for source-warning reasons.
- `src/app/draft-assistant/_contexts/DraftDataContext.tsx`: stops forwarding global warnings into recommendations.
- `src/app/api/draft/view-model/route.ts`: stops forwarding bundle warnings into recommendations.
- `src/app/mock-draft/MockDraftRoom.tsx`: aligns mock recommendations with the canonical warning-free path.
- `src/lib/algoMockDraft.ts`: aligns algorithm runs and saved mock recommendations with the canonical path.
- `scripts/draft/replay-sleeper-boards.ts`: aligns historical board replay with the canonical path.
- `tests/lib/sourceHealth.test.ts`: verifies only live draft sources are generated.
- `tests/lib/draftResults.test.ts`: verifies old Footballguys source snapshots remain parseable.
- `tests/lib/draftValue.test.ts`: keeps player-specific news-risk coverage after removing global warnings.
- `tests/api/draftViewModelRoute.test.ts`: updates the API boundary expectation.
- `tests/app/draft-assistant/PreviewPickDialog.test.tsx`: removes obsolete source-warning fixture data.

## Verification

- `pnpm test`: 289 tests passed
- `pnpm run lint`
- `pnpm run typecheck`
- `git diff --check`
- Codex review: no actionable correctness or regression issues